### PR TITLE
Support Rails 8

### DIFF
--- a/actionpack-fly.gemspec
+++ b/actionpack-fly.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
       .reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir = "exe"
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "actionpack", ">= 6.0", "< 8.0"
+  spec.add_runtime_dependency "actionpack", ">= 6.0", "< 9.0"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Rails 8 still uses the same infrastructure, the gemspec can be safely updated